### PR TITLE
Fix grep command line argument

### DIFF
--- a/authenticator_godaddy.sh
+++ b/authenticator_godaddy.sh
@@ -88,7 +88,7 @@ then
   while [ $I -le 5 ]
   do
     sleep 4
-    R=$(host -t txt "$RECORD_NAME.$DOMAIN" | grep $CERTBOT_VALIDATION)
+    R=$(host -t txt "$RECORD_NAME.$DOMAIN" | grep -e "$CERTBOT_VALIDATION")
     if [ $? -eq 0 ]
     then
       log "TEST $I > TOKEN FOUND"


### PR DESCRIPTION
Some certbot validation keys can cause grep to fail/not understand the pattern properly.  This can be protected by passing the pattern to grep as part of the '-e' argument.

Prior to this fix, certbot validation with a key of "-ssyJVeflGw2J8y4" resulted in the following error:
```
Error output from certbot_authenticator_godaddy.sh:
grep: invalid option -- 'J'
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.
grep: invalid option -- 'J'
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.
grep: invalid option -- 'J'
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.
grep: invalid option -- 'J'
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.
grep: invalid option -- 'J'
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.
grep: invalid option -- 'J'
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.
```