### PR TITLE
Make String Comparison Safe

### DIFF
--- a/authenticator_godaddy.sh
+++ b/authenticator_godaddy.sh
@@ -81,7 +81,7 @@ JSON_RESPONSE=$(curl -s -X PUT \
 -d "[{\"data\": \"$CERTBOT_VALIDATION\", \"ttl\": 600}]" \
 "https://api.godaddy.com/v1/domains/$DOMAIN/records/$RECORD_TYPE/$RECORD_NAME")
 
-if [ $JSON_RESPONSE == "{}" ]
+if [ "$JSON_RESPONSE" == "{}" ]
 then
   log "OK"
   I=0

--- a/cleanup_godaddy.sh
+++ b/cleanup_godaddy.sh
@@ -65,7 +65,7 @@ JSON_RESPONSE=$(curl -s -X PUT \
 -d "[{\"data\": \"$RECORD_VALUE\", \"ttl\": 600}]" \
 "https://api.godaddy.com/v1/domains/$DOMAIN/records/$RECORD_TYPE/$RECORD_NAME")
 
-if [ $JSON_RESPONSE == "{}" ]
+if [ "$JSON_RESPONSE" == "{}" ]
 then
   log "OK"
 else


### PR DESCRIPTION
If $JSON_RESPONSE is empty, then Bash throws a “unary operator” error.
This way, if $JSON_RESPONSE is empty, then the Bash comparison is “” ==
“{}”