### PR TITLE
Patch 1

### DIFF
--- a/authenticator_godaddy.sh
+++ b/authenticator_godaddy.sh
@@ -75,13 +75,13 @@ fi
 
 
 # Update the previous record
-JSON_RESPONSE=$(curl -s -X PUT \
+RESPONSE_CODE=$(curl -s -X PUT -w %{http_code} \
 -H "Authorization: sso-key $API_KEY:$API_SECRET" \
 -H "Content-Type: application/json" \
 -d "[{\"data\": \"$CERTBOT_VALIDATION\", \"ttl\": 600}]" \
 "https://api.godaddy.com/v1/domains/$DOMAIN/records/$RECORD_TYPE/$RECORD_NAME")
 
-if [ "$JSON_RESPONSE" == "{}" ]
+if [ "$RESPONSE_CODE" == "200" ]
 then
   log "OK"
   I=0
@@ -100,7 +100,7 @@ then
   done
 else
   log "KO"
-  log $JSON_RESPONSE
+  log $RESPONSE_CODE
 fi
 
 log "[END]"

--- a/cleanup_godaddy.sh
+++ b/cleanup_godaddy.sh
@@ -59,18 +59,18 @@ fi
 log "RECORD_NAME $RECORD_NAME"
 
 # Update the previous record to default value
-JSON_RESPONSE=$(curl -s -X PUT \
+RESPONSE_CODE=$(curl -s -X PUT -w %{http_code} \
 -H "Authorization: sso-key $API_KEY:$API_SECRET" \
 -H "Content-Type: application/json" \
 -d "[{\"data\": \"$RECORD_VALUE\", \"ttl\": 600}]" \
 "https://api.godaddy.com/v1/domains/$DOMAIN/records/$RECORD_TYPE/$RECORD_NAME")
 
-if [ "$JSON_RESPONSE" == "{}" ]
+if [ "$RESPONSE_CODE" == "{}" ]
 then
   log "OK"
 else
   log "KO"
-  log $JSON_RESPONSE
+  log $RESPONSE_CODE
 fi
 
 log "[END]"

--- a/cleanup_godaddy.sh
+++ b/cleanup_godaddy.sh
@@ -65,7 +65,7 @@ RESPONSE_CODE=$(curl -s -X PUT -w %{http_code} \
 -d "[{\"data\": \"$RECORD_VALUE\", \"ttl\": 600}]" \
 "https://api.godaddy.com/v1/domains/$DOMAIN/records/$RECORD_TYPE/$RECORD_NAME")
 
-if [ "$RESPONSE_CODE" == "{}" ]
+if [ "$RESPONSE_CODE" == "200" ]
 then
   log "OK"
 else


### PR DESCRIPTION
The status of used in this scripts GoDaddy API commands reflects on HTTP response code, which is equal to "200" on success and other on error.  Also, there are no JSON response on success, only HTTP code 200 with empty body and "text/plain" content type, so comparison with empty JSON ('{}') will fail.